### PR TITLE
Don't use bind in render()

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Then in JSX:
 
 ```js
 class MyComponent extends React.Component {
+
+    constructor() {
+        super();
+        this.onCreditCardChange = this.onCreditCardChange.bind(this);
+    }
+    
     onCreditCardChange(event) {
         // formatted pretty value
         console.log(event.target.value);
@@ -110,7 +116,7 @@ class MyComponent extends React.Component {
         return (
             <Cleave placeholder="Enter your credit card number"
                 options={{creditCard: true}}
-                onChange={this.onCreditCardChange.bind(this)} />
+                onChange={this.onCreditCardChange} />
         );
     }
 }

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Then in JSX:
 ```js
 class MyComponent extends React.Component {
 
-    constructor() {
-        super();
+    constructor(props, context) {
+        super(props, context);
         this.onCreditCardChange = this.onCreditCardChange.bind(this);
     }
     

--- a/doc/reactjs-component-usage.md
+++ b/doc/reactjs-component-usage.md
@@ -50,6 +50,10 @@ class MyComponent extends React.Component {
             phoneRawValue:      '',
             customRawValue:     ''
         };
+        
+        this.onCreditCardChange = this.onCreditCardChange.bind(this);
+        this.onPhoneChange = this.onPhoneChange.bind(this);
+        this.onCustomChange = this.onCustomChange.bind(this);
     }
 
     onCreditCardChange(event) {
@@ -68,13 +72,13 @@ class MyComponent extends React.Component {
         return (
             <div>
                 <Cleave placeholder="Enter your credit card number" options={{creditCard: true}}
-                        onChange={this.onCreditCardChange.bind(this)}/>
+                        onChange={this.onCreditCardChange}/>
 
                 <Cleave className="css-phone" options={{phone: true, phoneRegionCode: 'AU'}}
-                        onChange={this.onPhoneChange.bind(this)}/>
+                        onChange={this.onPhoneChange}/>
 
                 <Cleave options={{blocks: [4,3,3], delimiter: '-', numericOnly: true}}
-                        onChange={this.onCustomChange.bind(this)}/>
+                        onChange={this.onCustomChange}/>
 
                 <div>
                     <p>credit card: {this.state.creditCardRawValue}</p>


### PR DESCRIPTION
Updated doumentation / usage to not encourage using .bind() in render() as it's a performance hit.

For more info see https://daveceddia.com/avoid-bind-when-passing-props/