### PR TITLE
Ensure the event listeners are removed on destroy

### DIFF
--- a/dist/cleave.js
+++ b/dist/cleave.js
@@ -35,8 +35,10 @@ Cleave.prototype = {
 
         pps.maxLength = Cleave.Util.getMaxLength(pps.blocks);
 
-        owner.element.addEventListener('input', owner.onChange.bind(owner));
-        owner.element.addEventListener('keydown', owner.onKeyDown.bind(owner));
+        owner.onChangeListener = owner.onChange.bind(owner);
+        owner.onKeyDownListener = owner.onKeyDown.bind(owner);
+        owner.element.addEventListener('input', owner.onChangeListener);
+        owner.element.addEventListener('keydown', owner.onKeyDownListener);
 
         owner.initPhoneFormatter();
         owner.initDateFormatter();
@@ -238,8 +240,8 @@ Cleave.prototype = {
     destroy: function () {
         var owner = this;
 
-        owner.element.removeEventListener('input', owner.onChange.bind(owner));
-        owner.element.removeEventListener('keydown', owner.onKeyDown.bind(owner));
+        owner.element.removeEventListener('input', owner.onChangeListener);
+        owner.element.removeEventListener('keydown', owner.onKeyDownListener);
     },
 
     toString: function () {


### PR DESCRIPTION
Store the bound functions as variables to ensure they can be removed correctly.


Would fix #21 (afaict).

Untested :-s Just thought I'd quickly make a PR if helpful (or demonstrative).