### PR TITLE
change bower main to point to distributed cleave

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   ],
   "homepage": "https://github.com/nosir/cleave.js",
   "main": [
-    "src/Cleave.js"
+    "dist/cleave.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
When using the library with bower rather than NPM, it's not best practice to require files, therefore point to the distributed cleave by default for use with wiredep