### PR TITLE
Add `focus` method to React component

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -287,14 +287,17 @@ var Cleave = React.createClass({
     updateValueState: function () {
         this.setState({value: this.properties.result});
     },
+ 
     applyReference: function (element) {
         this._underlayingElement = element;
-    } 
+    },
+ 
     focus: function () {
         if (this._underlayingElement) {
             this._underlayingElement.focus();
         }
     },
+
     render: function () {
         var owner = this,
             { value, options, onKeyDown, onChange, onInit, ...propsToTransfer } = owner.props;

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -287,7 +287,14 @@ var Cleave = React.createClass({
     updateValueState: function () {
         this.setState({value: this.properties.result});
     },
-
+    applyReference: function (element) {
+        this._underlayingElement = element;
+    } 
+    focus: function () {
+        if (this._underlayingElement) {
+            this._underlayingElement.focus();
+        }
+    },
     render: function () {
         var owner = this,
             { value, options, onKeyDown, onChange, onInit, ...propsToTransfer } = owner.props;
@@ -298,6 +305,7 @@ var Cleave = React.createClass({
                 value={owner.state.value}
                 onKeyDown={owner.onKeyDown}
                 onChange={owner.onChange}
+                ref={this.applyReference}
                 {...propsToTransfer}
                 data-cleave-ignore={[value, options, onKeyDown, onChange, onInit]}
             />

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -293,7 +293,7 @@ var Cleave = React.createClass({
     },
  
     focus: function () {
-        if (this._inputElement) {
+        if (this._inputElement && typeof this._inputElement.focus === 'function') {
             this._inputElement.focus();
         }
     },

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -289,12 +289,12 @@ var Cleave = React.createClass({
     },
  
     applyReference: function (element) {
-        this._underlayingElement = element;
+        this._inputElement = element;
     },
  
     focus: function () {
-        if (this._underlayingElement) {
-            this._underlayingElement.focus();
+        if (this._inputElement) {
+            this._inputElement.focus();
         }
     },
 

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -308,7 +308,7 @@ var Cleave = React.createClass({
                 value={owner.state.value}
                 onKeyDown={owner.onKeyDown}
                 onChange={owner.onChange}
-                ref={this.applyReference}
+                ref={owner.applyReference}
                 {...propsToTransfer}
                 data-cleave-ignore={[value, options, onKeyDown, onChange, onInit]}
             />


### PR DESCRIPTION
I've added a pass-through focus method to access the underlying input elements focus method.

Problem:

`ref` was not picked up by `propsToTransfer`. 

Added the focus method and checking if it exists on the dom element.