### PR TITLE
[Issue-118] Add htmlRef to transfer ref into input field

### DIFF
--- a/doc/reactjs-component-usage.md
+++ b/doc/reactjs-component-usage.md
@@ -109,6 +109,42 @@ class MyComponent extends React.Component {
 ReactDOM.render(<MyComponent/>, document.getElementById('content'));
 ```
 
+### The ref callback
+
+Sometimes you might want to call the underlying input method, e.g: `focus`, `blur`, etc...
+
+Instead of using `ref`, you need to use `htmlRef` to pass the ref callback function, like this:
+
+```js
+class MyComponent extends React.Component {
+    constructor(props, context) {
+        super(props, context);
+        
+        this.onBtnClick = this.onBtnClick.bind(this);
+    }
+    
+    onBtnClick() {
+        this.ccInput.focus();
+    }
+
+    render() {
+        return (
+            <div>
+                <Cleave htmlRef={(ref) => this.ccInput = ref } options={{creditCard: true}}/>
+
+                <button onClick={this.onBtnClick}>Focus!</button>
+            </div>
+        );
+    }
+}
+
+ReactDOM.render(<MyComponent/>, document.getElementById('content'));
+```
+
+For more about ReactJS callback refs, check [here](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) 
+
+Also please be aware cleave.js doesn't support [The ref String Attribute](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-string-attribute), which is claimed as legacy by ReactJS (very likely to be deprecated in the future) 
+
 ### Webpack and Browserify config
 
 #### Webpack

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -290,16 +290,17 @@ var Cleave = React.createClass({
 
     render: function () {
         var owner = this,
-            { value, options, onKeyDown, onChange, onInit, ...propsToTransfer } = owner.props;
+            { value, options, onKeyDown, onChange, onInit, htmlRef, ...propsToTransfer } = owner.props;
 
         return (
             <input
                 type="text"
+                ref={htmlRef}
                 value={owner.state.value}
                 onKeyDown={owner.onKeyDown}
                 onChange={owner.onChange}
                 {...propsToTransfer}
-                data-cleave-ignore={[value, options, onKeyDown, onChange, onInit]}
+                data-cleave-ignore={[value, options, onKeyDown, onChange, onInit, htmlRef]}
             />
         );
     }


### PR DESCRIPTION
To solve the issue reported here: https://github.com/nosir/cleave.js/pull/116

The way you use `ref` in your component:
```js
this.ccInput.focus();
```
...
```js
<Cleave htmlRef={(ref) => this.ccInput = ref } options={{creditCard: true}}/>
```