### PR TITLE
Seems reasonable to allow 19 digits for unknown numbers

### DIFF
--- a/src/shortcuts/CreditCardDetector.js
+++ b/src/shortcuts/CreditCardDetector.js
@@ -111,7 +111,7 @@ var CreditCardDetector = {
         } else {
             return {
                 type:   'unknown',
-                blocks: blocks.general
+                blocks: strictMode ? blocks.generalStrict : blocks.general
             };
         }
     }


### PR DESCRIPTION
For example, we encountered 17-digit Maestro card beginning with 639002