### PR TITLE
Accept Nulls as initial Values

### DIFF
--- a/src/common/DefaultProperties.js
+++ b/src/common/DefaultProperties.js
@@ -47,7 +47,7 @@ var DefaultProperties = {
         target.rawValueTrimPrefix = !!opts.rawValueTrimPrefix;
         target.copyDelimiter = !!opts.copyDelimiter;
 
-        target.initValue = opts.initValue === undefined ? '' : opts.initValue.toString();
+        target.initValue = opts.initValue !== undefined && opts.initValue !== null ? opts.initValue.toString() : '';
 
         target.delimiter =
             (opts.delimiter || opts.delimiter === '') ? opts.delimiter :


### PR DESCRIPTION
Currently, if an initial value is null, it throws an error when it runs  opts.initValue.toString() . In addition to undefined, the default should also accept nulls.  