### PR TITLE
Set options to empty object if undefined

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -59,7 +59,10 @@ var Cleave = CreateReactClass({
             onKeyDown: onKeyDown || Util.noop
         };
 
-        (options || {}).initValue = value;
+        if (!options) {
+            options = {};
+        }
+        options.initValue = value;
 
         owner.properties = DefaultProperties.assign({}, options);
 


### PR DESCRIPTION
The initValue wasn't set correctly if the options were undefined. This commit fixes the problem, as the options will be set to an empty object.

This only effects the react part of the library.