### PR TITLE
Added conditional check if element is active and only call setSelecti…

### DIFF
--- a/src/Cleave.js
+++ b/src/Cleave.js
@@ -274,17 +274,15 @@ Cleave.prototype = {
 
         // If cursor was at the end of value, just place it back.
         // Because new value could contain additional chars.
-        if (oldValue.length === endPos) {
-            return;
-        }
-
-        if (elem.createTextRange) {
+        if (oldValue.length !== endPos && elem === document.activeElement) {
+          if ( elem.createTextRange ) {
             var range = elem.createTextRange();
 
             range.move('character', endPos);
             range.select();
-        } else {
+          } else {
             elem.setSelectionRange(endPos, endPos);
+          }
         }
     },
 

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -340,12 +340,14 @@ var Cleave = CreateReactClass({
             updateCursorPosition: false
         });
 
-        if (elem.createTextRange) {
+        if ( elem === document.activeElement ) {
+          if ( elem.createTextRange ) {
             var range = elem.createTextRange();
             range.move('character', cursorPosition);
             range.select();
-        } else {
+          } else {
             elem.setSelectionRange(cursorPosition, cursorPosition);
+          }
         }
     },
 


### PR DESCRIPTION
Added check so that the setCurrentSelection method body will only be executed when the current element is focus (activeElement in document). 

This prevents firing the events from all cleave inputs on initial render. In IE and Safari all inputs were focused otherwise (setSelectionRange triggers focus).