### PR TITLE
Loose package weight by publishing only required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "input"
   ],
   "version": "1.2.1",
+   "files": [
+    "src",
+    "dist"
+  ],
   "author": {
     "name": "Max Huang",
     "url": "http://github.com/nosir",


### PR DESCRIPTION
Lets not publish everything on npm.
Most users only cares about `src` and `dist` folders.

`npm` will still publish some of required files, for example-
```
package.json
README
CHANGES / CHANGELOG / HISTORY
LICENSE / LICENCE
NOTICE
```
Read more
https://docs.npmjs.com/files/package.json#files
