### PR TITLE
Shadow dom support

### DIFF
--- a/src/Cleave.js
+++ b/src/Cleave.js
@@ -295,13 +295,16 @@ Cleave.prototype = {
     },
 
     setCurrentSelection: function (endPos, oldValue) {
+        var owner = this,
+            pps = owner.properties;
+
         // If cursor was at the end of value, just place it back.
         // Because new value could contain additional chars.
         if (oldValue.length === endPos) {
             return;
         }
 
-        Cleave.Util.setSelection(this.element, endPos);
+        Cleave.Util.setSelection(this.element, endPos, pps.document);
     },
 
     updateValueState: function () {
@@ -357,7 +360,7 @@ Cleave.prototype = {
         }
 
         pps.backspace = false;
-        
+
         owner.element.value = value;
         owner.onInput(value);
     },

--- a/src/common/DefaultProperties.js
+++ b/src/common/DefaultProperties.js
@@ -63,7 +63,8 @@ var DefaultProperties = {
 
         target.blocks = opts.blocks || [];
         target.blocksLength = target.blocks.length;
-
+        
+        target.document = opts.document || document;
         target.root = (typeof global === 'object' && global) ? global : window;
 
         target.maxLength = 0;

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -155,7 +155,7 @@ var Util = {
         }, 1);
     },
 
-    setSelection: function (element, position) {
+    setSelection: function (element, position, document) {
         if (element !== document.activeElement) {
             return;
         }

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -155,8 +155,8 @@ var Util = {
         }, 1);
     },
 
-    setSelection: function (element, position, document) {
-        if (element !== document.activeElement) {
+    setSelection: function (element, position, doc) {
+        if (element !== doc.activeElement) {
             return;
         }
 


### PR DESCRIPTION
Current implementation of cleavejs doesn't support shadow dom, since it's using `document.activeElement` to query focused element which causes buggy behavior: when editing input value caret always jumps to the end

I propose to add optional parameter `document` to specify root document ( global document or any shadow root )
another option would be to go up through dom and look for shadow root but that would impact performance, so here's PR for adding optional document parameter 