### PR TITLE
Add ability to override decimal scale

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -26,6 +26,7 @@ var cleaveReactClass = CreateReactClass({
     componentWillReceiveProps: function (nextProps) {
         var owner = this,
             phoneRegionCode = (nextProps.options || {}).phoneRegionCode,
+            numeralDecimalScale = (nextProps.options || {}).numeralDecimalScale,
             newValue = nextProps.value;
 
         if (newValue !== undefined) {
@@ -41,6 +42,13 @@ var cleaveReactClass = CreateReactClass({
         if (phoneRegionCode && phoneRegionCode !== owner.properties.phoneRegionCode) {
             owner.properties.phoneRegionCode = phoneRegionCode;
             owner.initPhoneFormatter();
+            owner.onInput(owner.properties.result);
+        }
+
+        // Update numeral decimal scale
+        if (numeralDecimalScale && numeralDecimalScale !== owner.properties.numeralDecimalScale) {
+            owner.properties.numeralDecimalScale = numeralDecimalScale;
+            owner.initNumeralFormatter();
             owner.onInput(owner.properties.result);
         }
     },


### PR DESCRIPTION
This PR aims to introduce the ability of updating the decimal scale. One particular example where this feature would be much needed is when you want to change the decimal scale of an input used to display a currency amount. The decimal scale vary from currency to currency (mostly between FIAT and crypto currencies). With this, that decimal scale could be changed in realtime if for some reason, some chooses to change the currency associated with that amount input. 