### PR TITLE
Strip delimiters from prev result before comparing

### DIFF
--- a/src/Cleave.js
+++ b/src/Cleave.js
@@ -254,7 +254,8 @@ Cleave.prototype = {
         value = Util.stripDelimiters(value, pps.delimiter, pps.delimiters);
 
         // strip prefix
-        value = Util.getPrefixStrippedValue(value, pps.prefix, pps.prefixLength, pps.result);
+        var strippedPreviousResult = Util.stripDelimiters(pps.result, pps.delimiter, pps.delimiters);
+        value = Util.getPrefixStrippedValue(value, pps.prefix, pps.prefixLength, strippedPreviousResult);
 
         // strip non-numeric characters
         value = pps.numericOnly ? Util.strip(value, /[^\d]/g) : value;


### PR DESCRIPTION
This is a potential fix for #433 

There is a small oversight in the prefix stripping code which is comparing the non-delimited string against the previous, delimited string to see if the user deleted something. This caused it to always look like a deletion, which broke the formatting when typing "in" the prefix.

This fix updates it so that typing "in" the prefix inserts the letter after the prefix, which I believe was the original intention.