### PR TITLE
fix(Cleave.react): Cleave value doesn't update

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -31,7 +31,7 @@ var cleaveReactClass = CreateReactClass({
         if (newValue !== undefined) {
             newValue = newValue.toString();
 
-            if (newValue !== owner.properties.initValue && newValue !== owner.properties.result) {
+            if (newValue !== owner.properties.result) {
                 owner.properties.initValue = newValue;
                 owner.onInput(newValue, true);
             }


### PR DESCRIPTION
Fixes #389. That issue has a discussion on why removing the `initValue`
check might be preferable.