### PR TITLE
Fix issue #460 Jest Cleave snapshot testing throws error

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -401,6 +401,7 @@ var cleaveReactClass = CreateReactClass({
 
         if (!owner.element) {
             owner.setState({ value: pps.result });
+            return;
         }
 
         var endPos = owner.element.selectionEnd;


### PR DESCRIPTION
Fixes: Issue #460 

**Changes: Cleave.react.js**
- Return if `owner.element` is null