### PR TITLE
[ISSUE-476] Fixed missing dateMin, dateMax in DateFormatter call

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -144,7 +144,7 @@ var cleaveReactClass = CreateReactClass({
             return;
         }
 
-        pps.dateFormatter = new DateFormatter(pps.datePattern);
+        pps.dateFormatter = new DateFormatter(pps.datePattern, pps.dateMin, pps.dateMax);
         pps.blocks = pps.dateFormatter.getBlocks();
         pps.blocksLength = pps.blocks.length;
         pps.maxLength = Util.getMaxLength(pps.blocks);


### PR DESCRIPTION
*Fixes: Issue #476*

*Changes*: Cleave.react.js

Just passed dateMin, dateMax to DateFormatter