### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ However, this isn't meant to replace any validation or mask library, you should 
 npm install --save cleave.js
 ```
 
+#### CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/cleave.js@1/dist/cleave.min.js"></script>
+```
+
 #### old school
 Grab file from [dist](https://github.com/nosir/cleave.js/tree/master/dist) directory
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ npm install --save cleave.js
 
 #### CDN
 
-```html
-<script src="https://cdn.jsdelivr.net/npm/cleave.js@1/dist/cleave.min.js"></script>
-```
+cleave.js is available on [jsDelivr](https://www.jsdelivr.com/package/npm/cleave.js) and on [cdnjs.com](https://cdnjs.com/libraries/cleave.js)
 
 #### old school
 Grab file from [dist](https://github.com/nosir/cleave.js/tree/master/dist) directory


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.