### PR TITLE
libphonenumber: document how to bring your own

### DIFF
--- a/doc/phone-lib-addon.md
+++ b/doc/phone-lib-addon.md
@@ -20,6 +20,14 @@ Under `dist/addons` directory, you can find:
 
 - i18n all-in-one `cleave-phone.i18n.js` but with large size
 
+- bring your own libphonenumber instance (reduces bundle size)
+
+    ```JS
+    const AsYouTypeFormatter = require('google-libphonenumber').AsYouTypeFormatter;
+    window.Cleave = window.Cleave || {};
+    window.Cleave.AsYouTypeFormatter = AsYouTypeFormatter;
+    ```
+
 > You can find your country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) list.
 
 ### Simply HTML include


### PR DESCRIPTION
I figured this out today while trying to reduce overall bundle size and thought others might find this useful. I used https://github.com/ruimarinho/google-libphonenumber already, so I wanted to use it with Cleave instead of having another copy of the library.