### PR TITLE
feature: pass the name of the input in the event.

### DIFF
--- a/src/Cleave.js
+++ b/src/Cleave.js
@@ -381,6 +381,7 @@ Cleave.prototype = {
 
         pps.onValueChanged.call(owner, {
             target: {
+                name: owner.element.name,
                 value: pps.result,
                 rawValue: owner.getRawValue()
             }


### PR DESCRIPTION
Adding the name of the input to make it easy for a common pattern:

```js
handleInput = event => {
  this[event.target.name] = event.target.value;
};
```