### PR TITLE
Fix for signBeforePrefix breaking getRawValue

### DIFF
--- a/src/Cleave.js
+++ b/src/Cleave.js
@@ -278,7 +278,7 @@ Cleave.prototype = {
         // strip prefix
         value = Util.getPrefixStrippedValue(
             value, pps.prefix, pps.prefixLength,
-            pps.result, pps.delimiter, pps.delimiters, pps.noImmediatePrefix
+            pps.result, pps.delimiter, pps.delimiters, pps.signBeforePrefix, pps.noImmediatePrefix
         );
 
         // strip non-numeric characters
@@ -417,7 +417,7 @@ Cleave.prototype = {
             rawValue = owner.element.value;
 
         if (pps.rawValueTrimPrefix) {
-            rawValue = Util.getPrefixStrippedValue(rawValue, pps.prefix, pps.prefixLength, pps.result, pps.delimiter, pps.delimiters);
+            rawValue = Util.getPrefixStrippedValue(rawValue, pps.prefix, pps.prefixLength, pps.result, pps.delimiter, pps.delimiters, pps.signBeforePrefix);
         }
 
         if (pps.numeral) {

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -85,10 +85,15 @@ var Util = {
     // PREFIX-123   |   PEFIX-123     |     123
     // PREFIX-123   |   PREFIX-23     |     23
     // PREFIX-123   |   PREFIX-1234   |     1234
-    getPrefixStrippedValue: function (value, prefix, prefixLength, prevResult, delimiter, delimiters, noImmediatePrefix) {
+    getPrefixStrippedValue: function (value, prefix, prefixLength, prevResult, delimiter, delimiters, signBeforePrefix, noImmediatePrefix) {
         // No prefix
         if (prefixLength === 0) {
           return value;
+        }
+
+        if (signBeforePrefix && (value.slice(0, 1) == '-')) {
+            var prev = (prevResult.slice(0, 1) == '-') ? prevResult.slice(1) : prevResult;
+            return '-' + this.getPrefixStrippedValue(value.slice(1), prefix, prefixLength, prev, delimiter, delimiters, signBeforePrefix, noImmediatePrefix)
         }
 
         // Pre result prefix string does not match pre-defined prefix

--- a/test/fixtures/util.json
+++ b/test/fixtures/util.json
@@ -127,6 +127,7 @@
         "test12",
         "-",
         [],
+        false,
         false
       ],
       "expected": "123"
@@ -139,6 +140,7 @@
         "",
         "-",
         [],
+        false,
         false
       ],
       "expected": ""
@@ -151,6 +153,7 @@
         "",
         "-",
         [],
+        false,
         true
       ],
       "expected": "1"
@@ -176,6 +179,19 @@
         []
       ],
       "expected": "12"
+    },
+    {
+      "params": [
+        "-test123",
+        "test",
+        4,
+        "-test123",
+        "-",
+        [],
+        true,
+        false
+      ],
+      "expected":  "-123"
     }
   ]
 }

--- a/test/unit/Util_spec.js
+++ b/test/unit/Util_spec.js
@@ -25,7 +25,7 @@ describe('Util', function () {
         _.each(json.getPrefixStrippedValue, function (data) {
             var params = data.params;
             it('should get prefix stripped value for: ' + params[0] + ' as: ' + data.expected, function () {
-                Util.getPrefixStrippedValue(params[0], params[1], params[2], params[3], params[4], params[5], params[6]).should.eql(data.expected);
+                Util.getPrefixStrippedValue(params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]).should.eql(data.expected);
             });
         });
     });


### PR DESCRIPTION
Should hopefully fix issue #524 in a non-breaking manner.