### PR TITLE
Prevent cascading updates in componentDidUpdate

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -16,15 +16,14 @@ var cleaveReactClass = CreateReactClass({
         this.init();
     },
 
-    componentDidUpdate: function () {
+    componentDidUpdate: function (prevProps) {
         var owner = this,
             phoneRegionCode = (owner.props.options || {}).phoneRegionCode,
             newValue = owner.props.value,
             pps = owner.properties;
 
         owner.updateRegisteredEvents(owner.props);
-        if (newValue !== undefined && newValue !== null) {
-
+        if (prevProps.value !== newValue && newValue !== undefined && newValue !== null) {
             newValue = newValue.toString();
 
             if (newValue !== owner.properties.result) {
@@ -34,7 +33,8 @@ var cleaveReactClass = CreateReactClass({
         }
 
         // update phone region code
-        if (phoneRegionCode && phoneRegionCode !== owner.properties.phoneRegionCode) {
+        const prevPhoneRegionCode = (prevProps.options || {}).phoneRegionCode;
+        if (prevPhoneRegionCode !== phoneRegionCode && phoneRegionCode && phoneRegionCode !== owner.properties.phoneRegionCode) {
             owner.properties.phoneRegionCode = phoneRegionCode;
             owner.initPhoneFormatter();
             owner.onInput(owner.properties.result);


### PR DESCRIPTION
Fixes https://github.com/nosir/cleave.js/issues/568. Calls to `owner.onInput` within `componentDidUpdate` eventually triggered another `componentDidUpdate`

There may be further regressions with https://github.com/nosir/cleave.js/pull/527 since `componentWillReceiveProps` happens before the render cycle, but `componentDidUpdate` happens after. But would love to see this being fixed forward since https://github.com/nosir/cleave.js/pull/527 is still an awesome change!

Ran tests, linter, etc – lmk what else I should do.