### PR TITLE
Fix backspace bug when next delimiter partially match previous

### DIFF
--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -15,12 +15,13 @@ var Util = {
         }
 
         // multiple delimiters
-        var matchedDelimiter = '';
-        delimiters.forEach(function (current) {
+        for (let i = 0; i < delimiters.length; i++) {
+            var current = delimiters[i];
             if (value.slice(-current.length) === current) {
                 matchedDelimiter = current;
+                break;
             }
-        });
+        }
 
         return matchedDelimiter;
     },


### PR DESCRIPTION
when delimiters something like 
```
blocks: [3, 3, 3],
delimiters: [') ', ' '],
```
it's impossible to clear input with backspace - stuck at `111) `