### PR TITLE
add maestro to `onCreditCardTypeChanged`

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -94,7 +94,7 @@ A callback `Function`. Triggered after credit card type changes.
 
 The unique `String` argument `type` is the type of the detected credit, which can be:
 
-`amex` `mastercard` `visa` `diners` `discover` `jcb` `dankort` `instapayment` `uatp` `mir` `unionPay`
+`amex` `mastercard` `visa` `diners` `discover` `jcb` `dankort` `instapayment` `uatp` `mir` `unionPay` `maestro`
 
 ```js
 new Cleave('.my-input', {


### PR DESCRIPTION
Add maestro to `onCreditCardTypeChanged` in the doc. This feature is already been added to the library at #34 