### PR TITLE
rename rawValue since chrome experiments are setting this to readonly

### DIFF
--- a/dist/cleave-react-node.js
+++ b/dist/cleave-react-node.js
@@ -317,7 +317,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            owner.onInput(pps.prefix);
 	        }
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onFocus(event);
@@ -329,7 +329,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var owner = this,
 	            pps = owner.properties;
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onBlur(event);
@@ -351,7 +351,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        owner.onInput(event.target.value);
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onChange(event);

--- a/dist/cleave-react.js
+++ b/dist/cleave-react.js
@@ -15,6 +15,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 
+
 /******/ 		// Check if module is in cache
 /******/ 		if(installedModules[moduleId])
 /******/ 			return installedModules[moduleId].exports;
@@ -317,7 +318,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            owner.onInput(pps.prefix);
 	        }
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onFocus(event);
@@ -329,7 +330,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var owner = this,
 	            pps = owner.properties;
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onBlur(event);
@@ -351,7 +352,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        owner.onInput(event.target.value);
 
-	        event.target.rawValue = owner.getRawValue();
+	        event.target.cleaveRawValue = owner.getRawValue();
 	        event.target.value = pps.result;
 
 	        owner.registeredEvents.onChange(event);

--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -255,7 +255,7 @@ var cleaveReactClass = CreateReactClass({
             owner.onInput(pps.prefix);
         }
 
-        event.target.rawValue = owner.getRawValue();
+        event.target.cleaveRawValue = owner.getRawValue();
         event.target.value = pps.result;
 
         owner.registeredEvents.onFocus(event);
@@ -266,7 +266,7 @@ var cleaveReactClass = CreateReactClass({
     onBlur: function (event) {
         var owner = this, pps = owner.properties;
 
-        event.target.rawValue = owner.getRawValue();
+        event.target.cleaveRawValue = owner.getRawValue();
         event.target.value = pps.result;
 
         owner.registeredEvents.onBlur(event);
@@ -288,7 +288,7 @@ var cleaveReactClass = CreateReactClass({
 
         owner.onInput(event.target.value);
 
-        event.target.rawValue = owner.getRawValue();
+        event.target.cleaveRawValue = owner.getRawValue();
         event.target.value = pps.result;
 
         owner.registeredEvents.onChange(event);


### PR DESCRIPTION
Fixes #593 (sorta)

Chrome's "Experimental Web Platform Features" flag is setting `rawValue` on these events to `readonly`, causing errors with Cleave.js when users have this enabled.

I don't think this is the complete solution, because I'm sure there are people out there reading / interacting with the `rawValue` attribute that is being set here. This would require a major version upgrade on Cleave.js's part. Our project does not need this property, though, so I wanted to share this solution with others. Renaming it gets around the issues seen in Chrome in #593 .

I also could not run the tests to see what else might need to be worked on here, because the `fsevents` dependency seems to be really outdated. Again, my goal was mostly to stop the errors our users were seeing, and to share the solution.