### PR TITLE
Set initial lastInputValue to empty string

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -73,6 +73,7 @@ var cleaveReactClass = CreateReactClass({
         options.initValue = value;
 
         owner.properties = DefaultProperties.assign({}, options);
+        owner.lastInputValue = '';
 
         return {
             value: owner.properties.result,


### PR DESCRIPTION
I'm currently getting `Cannot read property 'slice' of undefined` error because lastInputValue is still undefined when user hasn't interacted with the input field.

```js
{
  "getPostDelimiter": function getPostDelimiter(value, delimiter, delimiters) {
    // single delimiter
    if (delimiters.length === 0) {
      return value.slice(-delimiter.length) === delimiter ? delimiter : "";
    }

    // multiple delimiters
    var matchedDelimiter = "";
    delimiters.forEach(function(current) {
      if (value.slice(-current.length) === current) {
        matchedDelimiter = current;
      }
    });

    return matchedDelimiter;
  }
}
```
