### PR TITLE
Avoid event triggering repeatedly

### DIFF
--- a/doc/vue.md
+++ b/doc/vue.md
@@ -16,7 +16,6 @@ Vue.directive('cleave', {
     update: (el) => {
         const event = new Event('input', {bubbles: true});
         setTimeout(function () {
-            el.value = el.cleave.properties.result
             el.dispatchEvent(event)
         }, 100);
     }
@@ -38,7 +37,6 @@ export default {
             update: (el) => {
                 const event = new Event('input', {bubbles: true});
                 setTimeout(function () {
-                    el.value = el.cleave.properties.result
                     el.dispatchEvent(event)
                 }, 100);
             }


### PR DESCRIPTION
Event is triggering repeatedly because the v-model is already assigning the value. In the following usage, there is no need to assign the element value again as the v-model is already used.