### PR TITLE
stop mutating options prop in react component

### DIFF
--- a/src/Cleave.react.js
+++ b/src/Cleave.react.js
@@ -70,9 +70,11 @@ var cleaveReactClass = CreateReactClass({
             options = {};
         }
 
-        options.initValue = value;
-
-        owner.properties = DefaultProperties.assign({}, options);
+        owner.properties = DefaultProperties.assign(
+            {},
+            Object.assign({}, options, { initValue: value })
+        );
+      
 
         return {
             value: owner.properties.result,


### PR DESCRIPTION
This fixes a bug where the react component will mutate the `options` object it gets as a prop, which is strongly frowned upon and can cause strange behavior when you expect this object to be readonly.