### PR TITLE
Handle missing value in Util.getPostDelimiter()

### DIFF
--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -9,6 +9,10 @@ var Util = {
     },
 
     getPostDelimiter: function (value, delimiter, delimiters) {
+        if (!value) {
+            return '';
+        }
+
         // single delimiter
         if (delimiters.length === 0) {
             return value.slice(-delimiter.length) === delimiter ? delimiter : '';


### PR DESCRIPTION
In automated testing, the last value may be null because no keydown event was sent to the input. In this case, we return an empty string.